### PR TITLE
[WiFiSSLLoop] Fast fail on lack of network connection

### DIFF
--- a/src/Validation/Meadow.Validation.F7/WiFiSSLLoopTest.cs
+++ b/src/Validation/Meadow.Validation.F7/WiFiSSLLoopTest.cs
@@ -53,7 +53,14 @@ namespace Meadow.Validation
             // just in case multiple connects come in
             await Task.Delay(1000);
 
-            for(int i = 0; i < 100; i++)
+            // Avoid running the requests if wi-fi never connected.
+            if (!wifi.IsConnected)
+            {
+                Resolver.Log.Error("Wi-Fi not connected");
+                return false;
+            }
+
+            for (int i = 0; i < 100; i++)
             {
                 await GetWebPageViaHttpClient("https://postman-echo.com/get?foo1=bar1&foo2=bar2", i);
             }

--- a/src/Validation/f7feather/wifi.config.yaml
+++ b/src/Validation/f7feather/wifi.config.yaml
@@ -1,3 +1,3 @@
 ﻿Credentials:
-    Ssid: [your wifi]
-    Password: [wifi password]
+    Ssid: "[your wifi]"
+    Password: "[wifi password]"


### PR DESCRIPTION
Adding a quick `wifi.IsConnected` check before making the 100 requests, especially in case someone forgets to set up Wi-Fi for their own desired network.

I'm not entirely sure what the timeout system is for here, but I was able to run this test, even with a connection failure, without needing that logic (by having wifi.config.yaml configured correctly).

On that same topic, I fixed the placeholder values in `wifi.config.yaml` so that the values are valid strings as part of the [question I posed recently](https://github.com/WildernessLabs/Meadow_Issues/issues/268). Currently, they weren't valid strings (`Ssid: [your wifi]` is actual setting it to a sequence). This means the config connection doesn't happen, which means you use whatever wi-fi network was previously configured successfully before (even if not a valid network). This will ensure you have it explicitly set up either in config or code.