### PR TITLE
Move HttpGet into exception block

### DIFF
--- a/src/Network/FeatherF7SoakTestRunner/MeadowApp.cs
+++ b/src/Network/FeatherF7SoakTestRunner/MeadowApp.cs
@@ -92,7 +92,7 @@ public class MeadowApp : App<F7FeatherV2>
             {
                 _displayService.Log($"{counter:N0}");
             }
-            Console.WriteLine($"Executing test: {counter:N0}");
+            Console.WriteLine($"{DateTime.Now:HH:mm:ss}: Executing test {counter:N0}");
             _test.Execute();
             if (_config.DelayBetweenCyclesMs > 0)
             {

--- a/src/Network/FeatherF7SoakTestRunner/MeadowApp.cs
+++ b/src/Network/FeatherF7SoakTestRunner/MeadowApp.cs
@@ -11,8 +11,8 @@ using SoakTests.Common;
 
 namespace FeatherF7Test;
 
-public class MeadowApp : App<F7FeatherV1>
-// public class MeadowApp : App<F7FeatherV2>
+// public class MeadowApp : App<F7FeatherV1>
+public class MeadowApp : App<F7FeatherV2>
 {
     /// <summary>
     /// OLED hardware object.  This object contains the OLED display and 8 LED objects.
@@ -92,6 +92,7 @@ public class MeadowApp : App<F7FeatherV1>
             {
                 _displayService.Log($"{counter:N0}");
             }
+            Console.WriteLine($"Executing test: {counter:N0}");
             _test.Execute();
             if (_config.DelayBetweenCyclesMs > 0)
             {

--- a/src/Network/FeatherF7SoakTestRunner/app.config.yaml
+++ b/src/Network/FeatherF7SoakTestRunner/app.config.yaml
@@ -15,7 +15,7 @@ SoakTest:
     #   What should we request?
     #
     # RequestUri: "http://192.168.1.239"
-    RequestUri: "http://postman-echo.com/get?foo1=bar1&foo2=bar2"
+    RequestUri: "https://postman-echo.com/get?foo1=bar1&foo2=bar2"
     #
     #   Number of test cycles.
     #

--- a/src/Network/FeatherF7SoakTestRunner/app.config.yaml
+++ b/src/Network/FeatherF7SoakTestRunner/app.config.yaml
@@ -10,16 +10,16 @@ SoakTest:
     #
     #   Name of the test to execute.
     #
-    TestName: "SocketSoakTest"
+    TestName: "HttpGetSoakTest"
     #
     #   What should we request?
     #
-    RequestUri: "http://192.168.1.239"
-    # RequestUri: "http://postman-echo.com/get?foo1=bar1&foo2=bar2"
+    # RequestUri: "http://192.168.1.239"
+    RequestUri: "http://postman-echo.com/get?foo1=bar1&foo2=bar2"
     #
     #   Number of test cycles.
     #
-    NumberOfCycles: 10
+    NumberOfCycles: 10000
     #
     #   Number of milliseconds between cycles.
     #

--- a/src/Network/SoakTests/Helpers.cs
+++ b/src/Network/SoakTests/Helpers.cs
@@ -26,10 +26,9 @@ public static class Helpers
     {
         using (HttpClient client = new HttpClient())
         {
-            HttpResponseMessage response = await client.GetAsync(uri);
-
             try
             {
+                HttpResponseMessage response = await client.GetAsync(uri);
                 response.EnsureSuccessStatusCode();
                 string responseBody = await response.Content.ReadAsStringAsync();
             }


### PR DESCRIPTION
* Made the default board a Feather V2 instead of a V1
* Added a `Console.Writeline` for every execution of test.
* Moved the HttpGet into the exception handler
* Changed the test defaults to `HttpGetSoakTest`, executed 10,000 times and requesting from Postman rather than an internal server