### PR TITLE
Add static HTTP client request tests

### DIFF
--- a/src/Network/HttpGetSoakTestProjLabV3/MainController.cs
+++ b/src/Network/HttpGetSoakTestProjLabV3/MainController.cs
@@ -89,7 +89,7 @@ namespace ProjectLabTest
             Thread.Sleep(Timeout.Infinite);
         }
 
-                /// <summary>
+        /// <summary>
         /// Get the specified resource from the network.
         /// </summary>
         /// <param name="uri">Network resource to request.</param>

--- a/src/Validation/Meadow.Validation.F7/WiFiSSLStaticHttpClientLoopTest.cs
+++ b/src/Validation/Meadow.Validation.F7/WiFiSSLStaticHttpClientLoopTest.cs
@@ -1,0 +1,110 @@
+﻿using Meadow.Hardware;
+using System;
+using System.Text;
+using System.Net.Http;
+using System.Threading.Tasks;
+using System.Diagnostics;
+
+namespace Meadow.Validation
+{
+    public class WiFiSSLStaticHttpClientLoopTest<T> : ITest<T>
+        where T : MeadowTestDevice
+    {
+        private const string BaseUrl = "https://postman-echo.com";
+        private const string Payload = "payload";
+        private static HttpClient _httpClient = new HttpClient
+        {
+            BaseAddress = new Uri(BaseUrl),
+            Timeout = TimeSpan.FromMinutes(5)
+        };
+        private static Stopwatch sw = new Stopwatch();
+
+        public async Task<bool> RunTest(T device)
+        {
+            string SSID = "TELUSDC1E"; // "BunnyMesh";
+            string PASSWORD = "tnrXFa6MVqAU"; //  "zxpvi29wt8";
+
+            var completed = false;
+            var success = false;
+
+            var wifi = (device as MeadowF7TestDevice).Device.NetworkAdapters.Primary<IWiFiNetworkAdapter>();
+            if (wifi == null) return false;
+
+            wifi.NetworkConnected += (s, e) =>
+            {
+                Resolver.Log.Info($"Network Connected. IP: {e.IpAddress}");
+            };
+
+            wifi.NetworkError += (s, a) =>
+            {
+                Resolver.Log.Info($"Network Error: {a.ErrorCode}");
+            };
+
+            try
+            {
+                Resolver.Log.Info($"Connecting to valid SSID with valid passcode...");
+
+                await wifi.Connect(SSID, PASSWORD);
+                completed = true;
+            }
+            catch (Exception ex)
+            {
+                Resolver.Log.Error($"Failed to connect: {ex.Message}");
+
+                completed = true;
+            }
+
+            success = wifi.IsConnected;
+
+            var timeout = 30;
+
+            while (!completed)
+            {
+                await Task.Delay(1000);
+                if (timeout-- <= 0) break;
+            }
+
+            // just in case multiple connects come in
+            await Task.Delay(1000);
+
+            // Avoid running the requests if wi-fi never connected.
+            if (!wifi.IsConnected)
+            {
+                Resolver.Log.Error("Wi-Fi not connected");
+                return false;
+            }
+
+            for (int i = 0; i < 300; i++)
+            {
+                await PostStaticHttpRequestAsync(i);
+            }
+
+            return success;
+        }
+
+        public async Task PostStaticHttpRequestAsync(int count)
+        {
+            Console.WriteLine($"Requesting {_httpClient.BaseAddress} using static HTTP client - {DateTime.Now} #{count} ");
+            
+            try
+            {
+                sw.Start();
+                using (var content = new StringContent(Payload, Encoding.UTF8))
+                using (var result = await _httpClient.PostAsync("post", content).ConfigureAwait(false))
+                {
+                    sw.Stop();
+                    Console.WriteLine($"Request {(result.IsSuccessStatusCode ? "succeeded" : "failed")} in {sw.Elapsed.TotalMilliseconds} ms");
+                    sw.Reset();
+                }
+            }
+            catch (TaskCanceledException)
+            {
+                Console.WriteLine("Request time out");
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine($"Request went sideways: {e.Message}");
+            }
+        }
+    }
+}

--- a/src/Validation/f7feather/MeadowApp.cs
+++ b/src/Validation/f7feather/MeadowApp.cs
@@ -60,6 +60,7 @@ namespace Meadow.Validation
                   new FileSystemTest<MeadowTestDevice>(),
                   new SQLiteTest<MeadowTestDevice>(),
                   new WiFiSSLLoopTest<MeadowTestDevice>(),
+                  new WiFiSSLStaticHttpClientLoopTest<MeadowTestDevice>(),
                   new WiFiScanForAccessPointsTest<MeadowTestDevice>(),
                 };
             }

--- a/src/Validation/gps-tracker/MeadowApp.cs
+++ b/src/Validation/gps-tracker/MeadowApp.cs
@@ -33,6 +33,7 @@ namespace Meadow.Validation
                   new FileSystemTest<MeadowTestDevice>(),
                   new SQLiteTest<MeadowTestDevice>(),
                   new WiFiSSLLoopTest<MeadowTestDevice>(),
+                  new WiFiSSLStaticHttpClientLoopTest<MeadowTestDevice>(),
                   new WiFiScanForAccessPointsTest<MeadowTestDevice>(),
 
                  //   new WiFiConnectionPositiveTest<MeadowTestDevice>(),


### PR DESCRIPTION
**Context**
The static HTTP client re-uses the same SSL context to reduce the TCP overhead when making requests to the same server, so it internally uses `poll` to check if the connection is usable or not. Given this significant difference between static and non-static HTTP clients, this PR aims to add static HTTP client requests to the validation tests.