### PR TITLE
Change BackColor to match new property name.

### DIFF
--- a/src/Connectivity/FeatherF7SoakTestRunner/Controllers/DisplayController.cs
+++ b/src/Connectivity/FeatherF7SoakTestRunner/Controllers/DisplayController.cs
@@ -79,7 +79,7 @@ internal class DisplayController
             Title = new Label(_rowMargin, 0, DisplayScreen.Width - (2 * _rowMargin), _titleHeight)
             {
                 Text = "",
-                BackColor = _foregroundColor,
+                BackgroundColor = _foregroundColor,
                 TextColor = _backgroundColor,
                 Font = _titleFont,
                 VerticalAlignment = VerticalAlignment.Center,

--- a/src/Connectivity/ProjLabV3SoakTestRunner/DisplayController.cs
+++ b/src/Connectivity/ProjLabV3SoakTestRunner/DisplayController.cs
@@ -44,7 +44,7 @@ internal class DisplayController
         {
             Text = "",
             TextColor = _backgroundColor,
-            BackColor = _foregroundColor,
+            BackgroundColor = _foregroundColor,
             Font = _titleFont,
             VerticalAlignment = VerticalAlignment.Center,
             HorizontalAlignment = HorizontalAlignment.Center
@@ -55,7 +55,7 @@ internal class DisplayController
         {
             Text = "",
             TextColor = _backgroundColor,
-            BackColor = _foregroundColor,
+            BackgroundColor = _foregroundColor,
             Font = _titleFont,
             VerticalAlignment = VerticalAlignment.Center,
             HorizontalAlignment = HorizontalAlignment.Center


### PR DESCRIPTION
`BackColor` property have been renamed in `Label`.